### PR TITLE
docs: explain build and run output

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ make
 make run
 ```
 
+`make` builds `build/szymos.iso`. `make run` starts that ISO with `qemu-system-i386`,
+so it is the quickest way to confirm the kernel boots before opening a pull request.
+If you only want to rebuild the ISO without starting QEMU, run `make` by itself.
+
 ---
 
 ## 🏗️ Project Structure


### PR DESCRIPTION
## Summary
- Clarify what `make` produces during the quick start
- Explain that `make run` launches the generated ISO with `qemu-system-i386`
- Note that contributors can run `make` alone when they only want to rebuild the ISO

Closes #3

## Testing
- `git diff --check`
- Verified README commands against `Makefile` targets: `make`, `make run`, `build/szymos.iso`, and `qemu-system-i386`

Not run locally: full build/QEMU smoke test because this Windows environment does not have `make`, `nasm`, `grub-mkrescue`, or `qemu-system-i386` installed.